### PR TITLE
Pagination Link Array changed to null

### DIFF
--- a/src/BaseController.php
+++ b/src/BaseController.php
@@ -654,9 +654,7 @@ class BaseController extends Controller
         if (! $single) {
             $meta = [
                 'paging' => [
-                    'links' => [
-
-                    ],
+                    'links' => null,
                 ],
             ];
             $limit      = $this->parser->getLimit();


### PR DESCRIPTION
If pagination is not applicable it was returning array but when we had pagination it was returning object. To make it uniformly return object we either do not set it or set it to null.